### PR TITLE
switched to python3.6 docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,4 @@ RUN pip install /opt/caliban-toolbox
 # Copy over toolbox notebooks
 COPY notebooks/ /notebooks/
 
-# Change matplotlibrc file to use the Agg backend
 CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--allow-root"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-# Use tensorflow/tensorflow as the base image
-# Change the build arg to edit the tensorflow version.
-# Only supporting python3.
-ARG TF_VERSION=1.11.0-gpu
-FROM tensorflow/tensorflow:${TF_VERSION}-py3
-
-RUN mkdir /notebooks/intro_to_tensorflow && \
-mv BUILD LICENSE /notebooks/*.ipynb intro_to_tensorflow/
+FROM python:3.6
 
 # System maintenance
 RUN apt-get update && apt-get install -y \
@@ -15,9 +8,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* && \
     /usr/local/bin/pip install --upgrade pip
 
-# Install necessary modules
-RUN pip install --no-cache-dir Cython==0.24.1 mock==1.3.0
-RUN pip install git+https://github.com/jfrelinger/cython-munkres-wrapper
+WORKDIR /notebooks
 
 # Copy the requirements.txt and install the dependencies
 COPY setup.py requirements.txt /opt/caliban-toolbox/
@@ -33,4 +24,4 @@ RUN pip install /opt/caliban-toolbox
 COPY notebooks/ /notebooks/
 
 # Change matplotlibrc file to use the Agg backend
-RUN echo "backend : Agg" > /usr/local/lib/python3.5/dist-packages/matplotlib/mpl-data/matplotlibrc
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--allow-root"]


### PR DESCRIPTION
The current docker uses a tensorflow image, which is overkill. It's also an older TF version which isn't compatible with python 3.6. I want to use regionprops_table, which requires skimage >0.16, so I swapped it out. 

I also removed a lot of the overhead that (I think) was the result of tensorflow dependencies. Let me know if anything I removed is important and needs to be kept!

Is there a reason we're maintaining a 3.5 and 3.6 test base? Or can we test only on 3.6 moving forward?