### PR TITLE
Pipeline automation and metadata tracking

### DIFF
--- a/caliban_toolbox/metadata.py
+++ b/caliban_toolbox/metadata.py
@@ -42,7 +42,7 @@ def make_experiment_metadata_file(raw_metadata):
 
     # add new blank fields
     blank_fields = ['job_ids', 'included_fovs', 'excluded_fovs', 'in_progress_fovs']
-    experiment_metadata.update({k: '' for k in blank_fields})
+    experiment_metadata.update({k: None for k in blank_fields})
 
     return experiment_metadata
 
@@ -64,7 +64,7 @@ def make_job_metadata_file(experiment_metadata, job_data):
 
     # add new blank fields
     blank_fields = ['job_id', 'included_fovs', 'excluded_fovs']
-    job_metadata.update({k: '' for k in blank_fields})
+    job_metadata.update({k: None for k in blank_fields})
 
     job_metadata['in_progress_fovs'] = job_data.fovs
 
@@ -72,7 +72,7 @@ def make_job_metadata_file(experiment_metadata, job_data):
 
 
 def update_job_metadata_file(job_metadata, update_dict):
-    """Updates a job metadata file with the status of individual images
+    """Updates a job metadata file with the status of individual fovs
 
     Args:
         job_metadata: the metadata file to be updated
@@ -99,6 +99,7 @@ def update_job_metadata_file(job_metadata, update_dict):
             raise ValueError('FOV {} was not in progress for this job'.format(fov))
 
     # remaining jobs that are not included or excluded are still in progress
+    # TODO: figure out workflow for remaining in progress jobs
     job_metadata['in_progress_fovs'] = in_progress
     job_metadata['included_fovs'] = included
     job_metadata['excluded_fovs'] = excluded

--- a/caliban_toolbox/metadata.py
+++ b/caliban_toolbox/metadata.py
@@ -1,0 +1,149 @@
+# Copyright 2016-2020 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/caliban-toolbox/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import json
+
+
+def make_experiment_metadata_file(raw_metadata):
+    """Creates a metadata file for a specific experiment
+
+    Args:
+        raw_metadata: metadata file from the raw ontology
+
+    Returns:
+        dict: pre-populated metadata file
+    """
+
+    # copy fields from raw metadata
+    keys_to_copy = ['PROJECT_ID', 'EXPERIMENT_ID']
+    experiment_metadata = {k: v for k, v in raw_metadata.items() if k in keys_to_copy}
+
+    # add new blank fields
+    blank_fields = ['job_ids', 'included_fovs', 'excluded_fovs', 'in_progress_fovs']
+    experiment_metadata.update({k: '' for k in blank_fields})
+
+    return experiment_metadata
+
+
+def make_job_metadata_file(experiment_metadata, job_data):
+    """Creates a metadata file for a job within an experiment
+
+    Args:
+        experiment_metadata: metadata file related to overall experiment
+        job_data: data to be included in this job
+
+    Returns:
+        dict: metadata file for a job
+    """
+
+    # copy fields from experiment metadata
+    keys_to_copy = ['PROJECT_ID', 'EXPERIMENT_ID']
+    job_metadata = {k: v for k, v in experiment_metadata.items() if k in keys_to_copy}
+
+    # add new blank fields
+    blank_fields = ['job_id', 'included_fovs', 'excluded_fovs']
+    job_metadata.update({k: '' for k in blank_fields})
+
+    job_metadata['in_progress_fovs'] = job_data.fovs
+
+    return job_metadata
+
+
+def update_job_metadata_file(job_metadata, update_dict):
+    """Updates a job metadata file with the status of individual images
+
+    Args:
+        job_metadata: the metadata file to be updated
+        update_dict: the dictionary containing the update stats for the job
+
+    Returns:
+        dict: updated metadata file
+    """
+
+    in_progress = job_metadata['in_progress_fovs']
+    included, excluded = update_dict['included'], update_dict['excluded']
+
+    # make sure supplied excluded and included images are in progress for this job
+    for fov in included:
+        if fov in in_progress:
+            in_progress.remove(fov)
+        else:
+            raise ValueError('FOV {} was not in progress for this job'.format(fov))
+
+    for fov in excluded:
+        if fov in in_progress:
+            in_progress.remove(fov)
+        else:
+            raise ValueError('FOV {} was not in progress for this job'.format(fov))
+
+    # remaining jobs that are not included or excluded are still in progress
+    job_metadata['in_progress_fovs'] = in_progress
+    job_metadata['included_fovs'] = included
+    job_metadata['excluded_fovs'] = excluded
+
+    return job_metadata
+
+
+def update_experiment_metadata(experiment_metadata, job_metadata):
+    """Updates an experiment metadata file with information from an individual job
+
+        Args:
+            experiment_metadata: metadata from an experiment
+            job_metadata: metadata from a job
+
+        Returns:
+            dict: updated experiment metadata file
+    """
+
+    exp_in_progress = experiment_metadata['in_progress_fovs']
+    exp_included = experiment_metadata['included_fovs']
+    exp_excluded = experiment_metadata['excluded_fovs']
+
+    in_progress = job_metadata['in_progress_fovs']
+    included = job_metadata['included_fovs']
+    excluded = job_metadata['excluded_fovs']
+
+    # first add any new in progress fovs from current job to experiment tracking
+    exp_in_progress = list(set(exp_in_progress + in_progress))
+
+    # move FOVs from in progress to included
+    for fov in included:
+        if fov in exp_in_progress:
+            exp_in_progress.remove(fov)
+            exp_included + [fov]
+
+    # move FOVs from in progress to excluded
+    for fov in excluded:
+        if fov in exp_in_progress:
+            exp_in_progress.remove(fov)
+            exp_included + [fov]
+
+    experiment_metadata['in_progress_fovs'] = exp_in_progress
+    experiment_metadata['included_fovs'] = exp_included
+    experiment_metadata['excluded_fovs'] = exp_excluded
+
+    return experiment_metadata
+
+

--- a/caliban_toolbox/metadata_test.py
+++ b/caliban_toolbox/metadata_test.py
@@ -29,11 +29,45 @@ from caliban_toolbox import metadata
 
 
 def _make_raw_metadata():
-    metadata = {'PROJECT_ID': np.random.randint(1, 100),
-                'EXPERIMENT_ID': np.random.randint(1, 100),
-                'TYPE': 'Cell Line'}
+    metadata_file = {'PROJECT_ID': np.random.randint(1, 100),
+                     'EXPERIMENT_ID': np.random.randint(1, 100),
+                     'TYPE': 'Cell Line'}
 
-    return metadata
+    return metadata_file
+
+
+def _make_blank_experiment_metadata():
+    blank_keys = ['PROJECT_ID', 'EXPERIMENT_ID', 'job_ids', 'included_fovs',
+                  'excluded_fovs', 'in_progress_fovs']
+    experiment_metadata = {k: None for k in blank_keys}
+
+    return experiment_metadata
+
+
+def _make_blank_job_metadata():
+    blank_keys = ['PROJECT_ID', 'EXPERIMENT_ID', 'job_id', 'included_fovs', 'excluded_fovs']
+    job_metadata = {k: None for k in blank_keys}
+
+    return job_metadata
+
+
+def _make_fov_ids(num_fovs):
+    all_fovs = np.random.randint(low=1, high=num_fovs*10, size=num_fovs)
+    fovs = ['fov_{}'.format(i) for i in all_fovs]
+
+    return fovs
+
+
+def _check_duplicate_keys(original_metadata, new_metadata, duplicate_keys):
+    for k in new_metadata.keys():
+        if k in duplicate_keys:
+            assert original_metadata[k] == new_metadata[k]
+
+
+def _check_blank_keys(metadata_file, blank_keys):
+    for k in metadata_file.keys():
+        if k in blank_keys:
+            assert metadata_file[k] is None
 
 
 def test_make_experiment_metadata_file():
@@ -41,7 +75,66 @@ def test_make_experiment_metadata_file():
     experiment_metadata = metadata.make_experiment_metadata_file(raw_metadata)
 
     duplicate_keys = ['PROJECT_ID', 'EXPERIMENT_ID']
-    for k in experiment_metadata.keys():
-        if k in duplicate_keys:
-            assert raw_metadata[k] == experiment_metadata[k]
+
+    _check_duplicate_keys(original_metadata=raw_metadata, new_metadata=experiment_metadata,
+                          duplicate_keys=duplicate_keys)
+
+    blank_fields = ['job_ids', 'included_fovs', 'excluded_fovs', 'in_progress_fovs']
+
+    _check_blank_keys(metadata_file=experiment_metadata, blank_keys=blank_fields)
+
+
+def test_make_job_metadata_file():
+    experiment_metadata = _make_raw_metadata()
+    fovs = _make_fov_ids(30)
+
+    job_metadata = metadata.make_job_metadata_file(experiment_metadata=experiment_metadata,
+                                                   job_data={'in_progress_fovs': fovs})
+
+    duplicate_keys = ['PROJECT_ID', 'EXPERIMENT_ID']
+
+    _check_duplicate_keys(original_metadata=experiment_metadata, new_metadata=job_metadata,
+                          duplicate_keys=duplicate_keys)
+
+    blank_fields = ['job_id', 'included_fovs', 'excluded_fovs']
+
+    _check_blank_keys(metadata_file=experiment_metadata, blank_keys=blank_fields)
+
+    assert np.all(fovs == job_metadata['in_progress_fovs'])
+
+
+def test_update_job_metadata_file():
+    job_metadata = _make_blank_job_metadata()
+    fovs = _make_fov_ids(100)
+    job_metadata['in_progress_fovs'] = fovs
+
+    #
+    included_fovs = list(np.random.choice(fovs, 80, replace=False))
+    excluded_fovs = [fov for fov in fovs if fov not in included_fovs]
+
+    updated_metadata = metadata.update_job_metadata_file(job_metadata=job_metadata,
+                                                         update_dict={'included': included_fovs,
+                                                                      'excluded': excluded_fovs})
+
+    assert np.all(updated_metadata['included_fovs'] == included_fovs)
+    assert np.all(updated_metadata['excluded_fovs'] == excluded_fovs)
+
+
+def test_update_experiment_metadata_file():
+    exp_metadata = _make_blank_experiment_metadata()
+    fovs = _make_fov_ids(100)
+    exp_metadata['in_progress_fovs'] = fovs
+
+    #
+    included_fovs = list(np.random.choice(fovs, 80, replace=False))
+    excluded_fovs = [fov for fov in fovs if fov not in included_fovs]
+
+    updated_metadata = metadata.update_job_metadata_file(job_metadata=job_metadata,
+                                                         update_dict={'included': included_fovs,
+                                                                      'excluded': excluded_fovs})
+
+    assert np.all(updated_metadata['included_fovs'] == included_fovs)
+    assert np.all(updated_metadata['excluded_fovs'] == excluded_fovs)
+
+
 

--- a/caliban_toolbox/metadata_test.py
+++ b/caliban_toolbox/metadata_test.py
@@ -1,0 +1,47 @@
+# Copyright 2016-2020 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/caliban-toolbox/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import numpy as np
+
+from caliban_toolbox import metadata
+
+
+def _make_raw_metadata():
+    metadata = {'PROJECT_ID': np.random.randint(1, 100),
+                'EXPERIMENT_ID': np.random.randint(1, 100),
+                'TYPE': 'Cell Line'}
+
+    return metadata
+
+
+def test_make_experiment_metadata_file():
+    raw_metadata = _make_raw_metadata()
+    experiment_metadata = metadata.make_experiment_metadata_file(raw_metadata)
+
+    duplicate_keys = ['PROJECT_ID', 'EXPERIMENT_ID']
+    for k in experiment_metadata.keys():
+        if k in duplicate_keys:
+            assert raw_metadata[k] == experiment_metadata[k]
+

--- a/caliban_toolbox/pipeline.py
+++ b/caliban_toolbox/pipeline.py
@@ -1,0 +1,108 @@
+# Copyright 2016-2020 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/caliban-toolbox/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+import json
+
+import numpy as np
+
+from caliban_toolbox import metadata
+
+
+def create_experiment_folder(data_loader_output, raw_metadata, base_dir):
+    """Takes the output of the data loader and creates an experiment folder
+
+    Args:
+        data_loader_output: files from an experiment to be processed
+        raw_metadata: metadata file from raw ontology
+        base_dir: directory where experiment folder will be created
+    """
+
+    experiment_id = raw_metadata['EXPERIMENT_ID']
+    experiment_folder = os.path.join(base_dir, experiment_id)
+    os.makedirs(experiment_folder)
+
+    # create metadata file
+    exp_metadata = metadata.make_experiment_metadata_file(raw_metadata)
+    exp_metadata['in_progress_fovs'] = data_loader_output.fovs
+
+    # save metadata file
+    with open(experiment_folder, 'w') as write_file:
+        json.dump(exp_metadata, write_file)
+
+
+def create_job_folder(experiment_dir, fov_num):
+    """Creates a folder to hold a single caliban job
+
+    Args:
+        experiment_dir: directory of relevant experiment
+        fov_num: number of FOVs to include in job
+    """
+
+    # Check if job folders already exist
+    folder_name = get_next_folder_name(experiment_dir)
+    os.makedirs(folder_name)
+
+    with open(os.path.join(experiment_dir, 'metadata.json')) as json_file:
+        exp_metadata = json.load(json_file)
+
+    new_fovs = get_fovs_from_metadata(exp_metadata)
+
+    job_metadata = metadata.make_job_metadata_file(exp_metadata, new_fovs)
+
+
+def save_stitched_npzs(stitched_channels, stitched_labels, save_dir):
+    """Takes corrected labels and channels and saves to NPZ for caliban round 2 checking
+
+    Args:
+        stitched_channels: original channel data
+        stitched_labels: stitched labels
+    """
+
+    for i in range(stitched_channels.shape[0]):
+        X = stitched_labels[i:(i + 1), ...]
+        y = stitched_labels[i:(i + 1), ...]
+        save_path = os.path.join(save_dir, stitched_labels.fovs.values[i] + '.npz')
+
+        np.savez(save_path, X=X, y=y)
+
+
+def process_stitched_data(base_dir):
+    """Takes stitched output and creates folder of NPZs for review
+
+    Args:
+        base_dir: directory to read from
+    """
+
+    stitched_labels = xr.load_dataarray(os.path.join(base_dir, 'output', 'stitched_labels.xr'))
+    channel_data = xr.load_dataarray(os.path.join(base_dir, 'channel_data.xr'))
+
+    correction_folder = os.path.join(base_dir, 'ready_to_correct')
+    os.makedirs(correction_folder)
+
+    save_stitched_npzs(stitched_channels=channel_data, stitched_labels=stitched_labels,
+                       save_dir=correction_folder)
+


### PR DESCRIPTION
This is still super prelim, but I wanted to get everyone's feedback at an early stage to avoid having to rewrite huge portions. 

The current problem with our workflow is that folders have to be created and named manually for each stage. For example, what do you call the folder you're downloading into, what do you name this experiment's caliban folder, what do you call the output dir, etc. 

The goal here is create a framework to handle these directory issues in a standardized way so that much of that work can be automated away. Here's how I imagine that going. 

pipeline.create_experiment_folder(): This function will create an experiment folder which will hold all of the data associated with annotating a specific experiment. The function takes a raw metadata file and the image stack created by the data_loader, and sets up an experiment directory and experiment metadata file. 
  - The metadata file will be created by metadata.create_experiment_metadata(), which knows which fields from the raw_metadata file need to be copied, which need to be parsed, and which new fields need to be created

pipeline.create_job_folder(): This function will create a job folder within an experiment folder that will handle the tasks associated with getting a subset of the data in the experiment folder annotated in a single crowdsource job. It takes as input the experiment metadata file, as well as a list of images that will be included in that job. 
- The metadata file will be created by metadata.create_job_metadata(), which smartly parses the required arguments

For a given experiment, we want to track the status of each image. I had mocked this up with 3 categories: in progress, included, and excluded. In progress would indicate that an image is currently being annotated, whereas excluded and included refer to the final status of an image after it has gone through the pipeline. Once a determination has been made for a specific job about the status of the images, metadata.update_job_metadata() would change the metadata file accordingly. Once a given job's metadata has been solidified, metadata.update_experiment_metadata() would take that updated job metadata file and use it to update the overall experiment metadata file. 

Once images have gone through this entire process, they will get stitched back together and saved to a 'ready_to_correct' folder. This is to review the crowd annotations. Once those are approved they get migrated into an NPZ and checked into DVC. 
