### PR TITLE
Patch data loader for single-frame ("Static") 2D data

### DIFF
--- a/caliban_toolbox/pre_annotation/data_loader.py
+++ b/caliban_toolbox/pre_annotation/data_loader.py
@@ -428,7 +428,7 @@ class UniversalDataLoader(object):
                     # Read in the image
                     img_set = tiff.imread(path)
                     raw_images.append(img_set)
-                    if img_set.shape[0] > max_frames:
+                    if img_set.shape[0] > max_frames and len(img_set.shape) > 2:
                         max_frames = img_set.shape[0]
 
         # TODO: the following wont be neccesary when num_frames exist


### PR DESCRIPTION
The data loader currently takes the first dimension of the image as the number of stacks, but for 2D data that is the rows axis, not the stack axis. Modified it to only do this for images with more than 2 dimensions.
