### PR TITLE
allow multiple npz key names

### DIFF
--- a/caliban_toolbox/utils/io_utils.py
+++ b/caliban_toolbox/utils/io_utils.py
@@ -200,13 +200,16 @@ def load_npzs(crop_dir, log_data, verbose=True):
             if os.path.exists(npz_path):
                 temp_npz = np.load(npz_path)
 
+                # determine how labels were named
+                labels_key = 'y' if 'y' in list(temp_npz.keys()) else 'annotated'
+
                 # last slice may be truncated, modify index
                 if slice == num_slices - 1:
-                    current_stack_len = temp_npz['X'].shape[1]
+                    current_stack_len = temp_npz[labels_key].shape[1]
                 else:
                     current_stack_len = slice_stack_len
 
-                stack[fov, :current_stack_len, crop, slice, ...] = temp_npz['y']
+                stack[fov, :current_stack_len, crop, slice, ...] = temp_npz[labels_key]
             else:
                 # npz not generated, did not contain any labels, keep blank
                 if verbose:

--- a/caliban_toolbox/utils/io_utils.py
+++ b/caliban_toolbox/utils/io_utils.py
@@ -201,7 +201,7 @@ def load_npzs(crop_dir, log_data, verbose=True):
                 temp_npz = np.load(npz_path)
 
                 # determine how labels were named
-                labels_key = 'y' if 'y' in list(temp_npz.keys()) else 'annotated'
+                labels_key = 'y' if 'y' in temp_npz else 'annotated'
 
                 # last slice may be truncated, modify index
                 if slice == num_slices - 1:


### PR DESCRIPTION
Some of the old NPZ files were generated with (raw, annotated) keys. The newer NPZs have been standardized to to (X, y). This PR modifies the toolbox to accept either input so that manual renaming isn't necessary