### PR TITLE
Save compressed NPZs

### DIFF
--- a/caliban_toolbox/pipeline.py
+++ b/caliban_toolbox/pipeline.py
@@ -64,7 +64,7 @@ def save_stitched_npzs(stitched_channels, stitched_labels, save_dir):
         y = stitched_labels[i:(i + 1), ...]
         save_path = os.path.join(save_dir, stitched_labels.fovs.values[i] + '.npz')
 
-        np.savez(save_path, X=X, y=y)
+        np.savez_compressed(save_path, X=X, y=y)
 
 
 def process_stitched_data(base_dir):
@@ -124,4 +124,4 @@ def create_combined_npz(npz_dir, save_name):
 
     X_concat, y_concat = concatenate_npz_files(npz_list=npz_list)
 
-    np.savez(os.path.join(npz_dir, save_name), X=X_concat, y=y_concat)
+    np.savez_compressed(os.path.join(npz_dir, save_name), X=X_concat, y=y_concat)

--- a/caliban_toolbox/utils/crop_utils.py
+++ b/caliban_toolbox/utils/crop_utils.py
@@ -110,7 +110,7 @@ def crop_helper(input_data, row_starts, row_ends, col_starts, col_ends, padding)
 
     # create xarray to hold crops
     cropped_stack = np.zeros((fov_len, stack_len, crop_num, slice_num,
-                              crop_size_row, crop_size_col, channel_len))
+                              crop_size_row, crop_size_col, channel_len), dtype=input_data.dtype)
 
     # labels for each index within a dimension
     coordinate_labels = [input_data.fovs, input_data.stacks, range(crop_num), input_data.slices,
@@ -152,7 +152,7 @@ def stitch_crops(crop_stack, log_data):
     fov_len, stack_len, _, _, row_size, col_size, _ = log_data['original_shape']
     row_padding, col_padding = log_data.get('row_padding', 0), log_data.get('col_padding', 0)
     stitched_labels = np.zeros((fov_len, stack_len, 1, 1, row_size + row_padding,
-                                col_size + col_padding, 1))
+                                col_size + col_padding, 1), dtype=crop_stack.dtype)
 
     row_starts, row_ends = log_data['row_starts'], log_data['row_ends']
     col_starts, col_ends = log_data['col_starts'], log_data['col_ends']

--- a/caliban_toolbox/utils/data_utils.py
+++ b/caliban_toolbox/utils/data_utils.py
@@ -158,17 +158,18 @@ def reorder_channels(new_channel_order, input_data, full_blank=True):
     return channel_xr_blanked
 
 
-def make_blank_labels(image_data):
+def make_blank_labels(image_data, dtype='uint16'):
     """Creates an xarray of blank y_labels which matches the image_data passed in
 
     Args:
         image_data: xarray of image channels used to get label names
+        dtype: dtype for labels
 
     Returns:
         xarray.DataArray: blank xarray of labeled data
     """
 
-    blank_data = np.zeros(image_data.shape[:-1] + (1,), dtype='int16')
+    blank_data = np.zeros(image_data.shape[:-1] + (1,), dtype=dtype)
 
     coords = [image_data.fovs, image_data.rows, image_data.cols, ['segmentation_label']]
     blank_xr = xr.DataArray(blank_data, coords=coords, dims=image_data.dims)

--- a/caliban_toolbox/utils/io_utils.py
+++ b/caliban_toolbox/utils/io_utils.py
@@ -87,7 +87,7 @@ def save_npzs_for_caliban(X_data, y_data, original_data, log_data, save_dir,
 
                 # save images as either npz or xarray
                 if save_format == 'npz':
-                    np.savez(save_path + '.npz', X=channels, y=labels)
+                    np.savez_compressed(save_path + '.npz', X=channels, y=labels)
 
                 elif save_format == 'xr':
                     raise NotImplementedError()
@@ -105,7 +105,7 @@ def save_npzs_for_caliban(X_data, y_data, original_data, log_data, save_dir,
 
                 # save images as either npz or xarray
                 if save_format == 'npz':
-                    np.savez(save_path + '.npz', X=channels, y=labels)
+                    np.savez_compressed(save_path + '.npz', X=channels, y=labels)
 
                 elif save_format == 'xr':
                     raise NotImplementedError()
@@ -116,7 +116,7 @@ def save_npzs_for_caliban(X_data, y_data, original_data, log_data, save_dir,
 
             # save images as either npz or xarray
             if save_format == 'npz':
-                np.savez(save_path + '.npz', X=channels, y=labels)
+                np.savez_compressed(save_path + '.npz', X=channels, y=labels)
 
             elif save_format == 'xr':
                 raise NotImplementedError()
@@ -126,6 +126,7 @@ def save_npzs_for_caliban(X_data, y_data, original_data, log_data, save_dir,
     log_data['original_shape'] = original_data.shape
     log_data['slice_stack_len'] = X_data.shape[1]
     log_data['save_format'] = save_format
+    log_data['label_dtype'] = str(y_data.dtype)
 
     log_path = os.path.join(save_dir, 'log_data.json')
     with open(log_path, 'w') as write_file:
@@ -178,6 +179,7 @@ def load_npzs(crop_dir, log_data, verbose=True):
     fov_names = log_data['fov_names']
     fov_len, stack_len, _, _, row_size, col_size, _ = log_data['original_shape']
     save_format = log_data['save_format']
+    label_dtype = log_data['label_dtype']
 
     # if cropped/sliced, get size of dimensions. Otherwise, use size in original data
     row_crop_size = log_data.get('row_crop_size', row_size)
@@ -187,7 +189,7 @@ def load_npzs(crop_dir, log_data, verbose=True):
     # if cropped/sliced, get number of crops/slices
     num_crops, num_slices = log_data.get('num_crops', 1), log_data.get('num_slices', 1)
     stack = np.zeros((fov_len, slice_stack_len, num_crops,
-                      num_slices, row_crop_size, col_crop_size, 1))
+                      num_slices, row_crop_size, col_crop_size, 1), dtype=label_dtype)
     saved_files = os.listdir(crop_dir)
 
     # for each fov, loop over each 2D crop and 3D slice

--- a/caliban_toolbox/utils/slice_utils.py
+++ b/caliban_toolbox/utils/slice_utils.py
@@ -91,7 +91,7 @@ def slice_helper(data_xr, slice_start_indices, slice_end_indices):
 
     # create xarray to hold slices
     slice_data = np.zeros((fov_len, sliced_stack_len, crop_num,
-                           slice_num, row_len, col_len, chan_len))
+                           slice_num, row_len, col_len, chan_len), dtype=data_xr.dtype)
 
     # labels for each index within a dimension
     coordinate_labels = [data_xr.fovs, range(sliced_stack_len), range(crop_num), range(slice_num),
@@ -143,7 +143,8 @@ def stitch_slices(slice_stack, log_data):
     slice_end_indices = log_data['slice_end_indices']
     num_slices, fov_names = log_data['num_slices'], log_data['fov_names']
 
-    stitched_slices = np.zeros((fov_len, stack_len, crop_num, 1, row_len, col_len, 1))
+    stitched_slices = np.zeros((fov_len, stack_len, crop_num, 1, row_len, col_len, 1),
+                               dtype=slice_stack.dtype)
 
     # loop slice indices to generate sliced data
     for i in range(num_slices - 1):


### PR DESCRIPTION
This PR switches the default from np.savez() to np.savez_compressed() to reduce file size. It also passes in the dtype parameter from the input data to all of the crops to allow specification of a smaller dtype to be propagated throughout the pipeline. 