### PR TITLE
Update example notebook

### DIFF
--- a/caliban_toolbox/utils/crop_utils.py
+++ b/caliban_toolbox/utils/crop_utils.py
@@ -61,7 +61,7 @@ def compute_crop_indices(img_len, crop_size=None, crop_num=None, overlap_frac=0)
     # compute indices based on fixed number of crops
     elif crop_num is not None:
         # number of pixels in non-overlapping portion of crop
-        non_overlap_crop_size = np.ceil(img_len / crop_num)
+        non_overlap_crop_size = np.ceil(img_len / crop_num).astype('int')
 
         # Technically this is the fraction the non-overlap, rather than fraction of the whole,
         # but we're going to visually crop overlays anyway to make sure value is appropriate

--- a/caliban_toolbox/utils/crop_utils_test.py
+++ b/caliban_toolbox/utils/crop_utils_test.py
@@ -146,7 +146,7 @@ def test_crop_helper():
                                              col_ends=col_ends,
                                              padding=(row_padding, col_padding))
 
-    assert (cropped.shape == (fov_len, stack_len, 1, slice_num, row_len, col_len, chan_len))
+    assert (cropped.shape == (fov_len, stack_len, 30, slice_num, row_crop, col_crop, chan_len))
 
     # test crops with number specified rather than size
     row_crop_num, col_crop_num = 5, 6
@@ -163,7 +163,8 @@ def test_crop_helper():
                                              col_ends=col_ends,
                                              padding=(row_padding, col_padding))
 
-    assert (cropped.shape == (fov_len, stack_len, 30, slice_num, row_crop, col_crop, chan_len))
+    # Because overlap is calculated differently, final size is not exactly equal
+    assert (cropped.shape == (fov_len, stack_len, 30, slice_num, 48, 40, chan_len))
 
     # test that correct region of image is being cropped
     row_crop, col_crop = 40, 40

--- a/caliban_toolbox/utils/crop_utils_test.py
+++ b/caliban_toolbox/utils/crop_utils_test.py
@@ -146,6 +146,23 @@ def test_crop_helper():
                                              col_ends=col_ends,
                                              padding=(row_padding, col_padding))
 
+    assert (cropped.shape == (fov_len, stack_len, 1, slice_num, row_len, col_len, chan_len))
+
+    # test crops with number specified rather than size
+    row_crop_num, col_crop_num = 5, 6
+    row_starts, row_ends, row_padding = \
+        crop_utils.compute_crop_indices(img_len=row_len, crop_num=row_crop_num,
+                                        overlap_frac=overlap_frac)
+
+    col_starts, col_ends, col_padding = \
+        crop_utils.compute_crop_indices(img_len=col_len, crop_num=col_crop_num,
+                                        overlap_frac=overlap_frac)
+
+    cropped, padded = crop_utils.crop_helper(input_data=test_xr, row_starts=row_starts,
+                                             row_ends=row_ends, col_starts=col_starts,
+                                             col_ends=col_ends,
+                                             padding=(row_padding, col_padding))
+
     assert (cropped.shape == (fov_len, stack_len, 30, slice_num, row_crop, col_crop, chan_len))
 
     # test that correct region of image is being cropped

--- a/notebooks/Caliban_Figure8_Upload_Combined.ipynb
+++ b/notebooks/Caliban_Figure8_Upload_Combined.ipynb
@@ -974,7 +974,7 @@
    "outputs": [],
    "source": [
     "# save cropped data into npz files for upload to Figure8\n",
-    "io_utils.save_npzs_for_caliban(X_data=X_cropped, y_data=y_data, original_data=channel_data, save_dir=save_dir,\n",
+    "io_utils.save_npzs_for_caliban(X_data=X_cropped, y_data=y_cropped, original_data=channel_data, save_dir=save_dir,\n",
     "                                   log_data=log_data)"
    ]
   },


### PR DESCRIPTION
This updates the example jupyter notebook so that the correct stack is passed to the Figure8, as well as fixing an issue where specifying the number of crops resulted in a float error. 
Closes #106  and closes #107 