### PR TITLE
resize individual images within NPZ

### DIFF
--- a/caliban_toolbox/build.py
+++ b/caliban_toolbox/build.py
@@ -28,7 +28,111 @@ import math
 
 import numpy as np
 
+from skimage.measure import regionprops_table
+
 from deepcell_toolbox.utils import resize, tile_image
+
+
+def compute_cell_size(npz_file, method='median', by_image=True):
+    """Computes the typical cell size from a stack of labeled data
+
+    Args:
+        npz_file: Paired X and y data
+        method: one of (mean, median) used to compute the cell size
+        by_image: if true, cell size is reported for each image in npz_file. Otherwise,
+            the cell size across the entire npz is returned
+
+    Returns:
+        cell_sizes: list of typical cell size in NPZ
+
+    Raises: ValueError if invalid method supplied
+    Raises: ValueError if data does have len(shape) of 4
+    """
+
+    valid_methods = set(['median', 'mean'])
+    if method not in valid_methods:
+        raise ValueError('Invalid method supplied: got {}, '
+                         'method must be one of {}'.format(method, valid_methods))
+
+    # initialize variables
+    cell_sizes = []
+
+    if not by_image:
+        cell_size_acum = []
+
+    labels = npz_file['y']
+
+    if len(labels.shape) != 4:
+        raise ValueError('Labeled data must be 4D')
+
+    for i in range(labels.shape[0]):
+        current_label = labels[i, :, :, 0]
+        area = regionprops_table(current_label.astype('int'), properties=['area'])['area']
+
+        # compute separately for each image
+        if by_image:
+            if method == 'mean':
+                current_cell_size = np.mean(area)
+            elif method == 'median':
+                current_cell_size = np.median(area)
+            else:
+                raise ValueError('Invalid method supplied')
+
+            cell_sizes.append(current_cell_size)
+
+        # compute for all images at once after loop finishes
+        else:
+            cell_size_acum.append(area)
+
+    # compute summary across entire NPZ
+    if not by_image:
+        all_cell_sizes = np.concatenate(cell_size_acum)
+        if method == 'mean':
+            cell_sizes = [np.mean(all_cell_sizes)]
+        elif method == 'median':
+            cell_sizes = [np.median(all_cell_sizes)]
+        else:
+            raise ValueError('Invalid method supplied')
+
+    return cell_sizes
+
+
+def reshape_training_image(X_data, y_data, resize_ratio, final_size, stride_ratio):
+    """Takes a stack of X and y data and reshapes and crops them to match output dimensions
+
+    Args:
+        X_data: 4D numpy array of image data
+        y_data: 4D numpy array of labeled data
+        resize_ratio: resize ratio for the images
+        final_size: the desired shape of the output image
+        stride_ratio: amount of overlap between crops (1 is no overlap, 0.5 is half crop size)
+
+
+    Returns:
+        reshaped_X, reshaped_y: resized and cropped version of input images
+    """
+
+    # resize if needed
+    # TODO: Add tolerance to control when resizing happens
+    if resize_ratio != 1:
+        new_shape = (int(X_data.shape[1] * resize_ratio),
+                     int(X_data.shape[2] * resize_ratio))
+
+        X_data = resize(data=X_data, shape=new_shape)
+        y_data = resize(data=y_data, shape=new_shape, labeled_image=True)
+
+    # crop if needed
+    if X_data.shape[1:3] != final_size:
+        # pad image so that crops divide evenly
+        X_data = pad_image_stack(images=X_data, crop_size=final_size)
+        y_data = pad_image_stack(images=y_data, crop_size=final_size)
+
+        # create x and y crops
+        X_data, _ = tile_image(image=X_data, model_input_shape=final_size,
+                               stride_ratio=stride_ratio)
+        y_data, _ = tile_image(image=y_data, model_input_shape=final_size,
+                               stride_ratio=stride_ratio)
+    return X_data, y_data
 
 
 def pad_image_stack(images, crop_size):
@@ -64,48 +168,62 @@ def combine_npz_files(npz_list, resize_ratios, stride_ratio=1, final_size=(256, 
 
     Args:
         npz_list: list of NPZ files to combine. Currently only works on 2D static data
-        resize_ratios: ratio used to resize each NPZ if data is of different resolutions
+        resize_ratios: ratio used to resize each NPZ if data is of different resolutions. Must
+            be either 1 for each NPZ file, or 1 for each image within the NPZ file
         stride_ratio: amount of overlap between crops (1 is no overlap, 0.5 is half crop size)
         final_size: size of the final crops to be produced
+
     Returns:
         np.array: array containing resized and cropped data from all input NPZs
-    Raises:
-        ValueError: If resize ratios are not integers
-    """
 
+    Raises:
+        ValueError: If mismatch between number of resize ratios and number of images
+    """
     combined_x = []
     combined_y = []
 
     for idx, npz in enumerate(npz_list):
         current_x = npz['X']
         current_y = npz['y']
-
-        # resize if needed
-        # TODO: Add tolerance to control when resizing happens
         current_resize = resize_ratios[idx]
-        if current_resize != 1:
-            new_shape = (int(current_x.shape[1] * current_resize),
-                         int(current_x.shape[2] * current_resize))
 
-            current_x = resize(data=current_x, shape=new_shape)
-            current_y = resize(data=current_y, shape=new_shape, labeled_image=True)
+        # same resize value for entire NPZ file
+        if len(current_resize) == 1:
+            current_x, current_y = reshape_training_image(X_data=current_x,
+                                                          y_data=current_y,
+                                                          resize_ratio=current_resize[0],
+                                                          final_size=final_size,
+                                                          stride_ratio=stride_ratio)
+            combined_x.append(current_x)
+            combined_y.append(current_y)
 
-        # crop if needed
-        if current_x.shape[1:3] != final_size:
+        # different resize value for each image within the NPZ file
+        else:
+            unique_x, unique_y = [], []
+            if len(current_resize) != current_x.shape[0]:
+                raise ValueError('Resize ratios must have same length as image data.'
+                                 'Provided resize ratios has length {} '
+                                 'and image data has shape {}'.format(len(resize_ratios),
+                                                                      current_x.shape))
+            # loop over each image and resize + crop appropriately
+            for img in range(current_x.shape[0]):
+                x_batch, y_batch = reshape_training_image(X_data=current_x[img:(img + 1)],
+                                                          y_data=current_y[img:(img + 1)],
+                                                          resize_ratio=current_resize[img],
+                                                          final_size=final_size,
+                                                          stride_ratio=stride_ratio)
+                unique_x.append(x_batch)
+                unique_y.append(y_batch)
 
-            # pad image so that crops divide evenly
-            current_x = pad_image_stack(images=current_x, crop_size=final_size)
-            current_y = pad_image_stack(images=current_y, crop_size=final_size)
+            # combine all images from this NPZ together
+            current_x = np.concatenate(unique_x, axis=0)
+            current_y = np.concatenate(unique_y, axis=0)
 
-            # create x and y crops
-            current_x, _ = tile_image(image=current_x, model_input_shape=final_size,
-                                      stride_ratio=stride_ratio)
-            current_y, _ = tile_image(image=current_y, model_input_shape=final_size,
-                                      stride_ratio=stride_ratio)
+            # add combined images from this NPZ onto main accumulator list
+            combined_x.append(current_x)
+            combined_y.append(current_y)
 
-        combined_x.append(current_x)
-        combined_y.append(current_y)
-
+    # combine all images from all NPZs together
     combined_x = np.concatenate(combined_x, axis=0)
     combined_y = np.concatenate(combined_y, axis=0)
 

--- a/caliban_toolbox/build_test.py
+++ b/caliban_toolbox/build_test.py
@@ -23,22 +23,117 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import pytest
+
 import numpy as np
 
 from caliban_toolbox import build
 
 
-def _make_npzs(size, num):
+def _make_npzs(sizes, num_images):
     npz_list = []
 
-    for i in range(num):
-        x = np.zeros((1, ) + size + (4, ))
-        y = np.zeros((1,) + size + (1,))
+    for i in range(len(num_images)):
+        x = np.zeros((num_images[i], ) + sizes[i] + (4, ))
+        y = np.zeros((num_images[i], ) + sizes[i] + (1, ))
         npz = {'X': x, 'y': y}
 
         npz_list.append(npz)
 
     return npz_list
+
+
+def test_compute_cell_size():
+    labels = np.zeros((3, 40, 40, 1), dtype='int')
+    labels[0, :10, :10, 0] = 1
+    labels[0, 20:25, 20:25, 0] = 2
+    labels[0, 12:14, 16:18] = 3
+
+    labels[1, :4, :4, 0] = 2
+    labels[1, 30:35, 35:40, 0] = 3
+    labels[1, 36:39, 30:33, 0] = 1
+
+    labels[2, 30:39, 20:29] = 1
+
+    example_npz = {'y': labels}
+
+    cell_sizes = build.compute_cell_size(npz_file=example_npz, method='median', by_image=True)
+    assert np.all(cell_sizes == [25, 16, 81])
+
+    cell_sizes = build.compute_cell_size(npz_file=example_npz, method='median', by_image=False)
+    assert cell_sizes == [25]
+
+    cell_sizes = build.compute_cell_size(npz_file=example_npz, method='mean', by_image=True)
+    assert np.all(np.round(cell_sizes, 2) == [43, 16.67, 81])
+
+    cell_sizes = build.compute_cell_size(npz_file=example_npz, method='mean', by_image=False)
+    assert np.round(cell_sizes, 2) == [37.14]
+
+    # incorrect method
+    with pytest.raises(ValueError):
+        _ = build.compute_cell_size(npz_file=example_npz, method='bad_method', by_image=True)
+
+    # incorrect input data
+    with pytest.raises(ValueError):
+        _ = build.compute_cell_size(npz_file={'y': labels[0]}, method='bad_method', by_image=True)
+
+
+def test_reshape_training_image():
+    # test without resizing or cropping
+    X_data, y_data = np.zeros((5, 40, 40, 3)), np.zeros((5, 40, 40, 2))
+    resize_ratio = 1
+    final_size = (40, 40)
+    stride_ratio = 1
+
+    reshaped_X, reshaped_y = build.reshape_training_image(X_data=X_data,
+                                                          y_data=y_data,
+                                                          resize_ratio=resize_ratio,
+                                                          final_size=final_size,
+                                                          stride_ratio=stride_ratio)
+    assert reshaped_X.shape == X_data.shape
+    assert reshaped_y.shape == y_data.shape
+
+    # test with just cropping
+    X_data, y_data = np.zeros((5, 80, 40, 3)), np.zeros((5, 80, 40, 2))
+    resize_ratio = 1
+    final_size = (40, 40)
+    stride_ratio = 1
+
+    reshaped_X, reshaped_y = build.reshape_training_image(X_data=X_data,
+                                                          y_data=y_data,
+                                                          resize_ratio=resize_ratio,
+                                                          final_size=final_size,
+                                                          stride_ratio=stride_ratio)
+    assert list(reshaped_X.shape) == [X_data.shape[0] * 2] + list(final_size) + [X_data.shape[-1]]
+    assert list(reshaped_y.shape) == [y_data.shape[0] * 2] + list(final_size) + [y_data.shape[-1]]
+
+    # test with just resizing
+    X_data, y_data = np.zeros((5, 40, 40, 3)), np.zeros((5, 40, 40, 2))
+    resize_ratio = 1
+    final_size = (80, 80)
+    stride_ratio = 2
+
+    reshaped_X, reshaped_y = build.reshape_training_image(X_data=X_data,
+                                                          y_data=y_data,
+                                                          resize_ratio=resize_ratio,
+                                                          final_size=final_size,
+                                                          stride_ratio=stride_ratio)
+    assert list(reshaped_X.shape) == [X_data.shape[0]] + list(final_size) + [X_data.shape[-1]]
+    assert list(reshaped_y.shape) == [y_data.shape[0]] + list(final_size) + [y_data.shape[-1]]
+
+    # test with resizing and cropping
+    X_data, y_data = np.zeros((5, 40, 40, 3)), np.zeros((5, 40, 40, 2))
+    resize_ratio = 2
+    final_size = (40, 40)
+    stride_ratio = 2
+
+    reshaped_X, reshaped_y = build.reshape_training_image(X_data=X_data,
+                                                          y_data=y_data,
+                                                          resize_ratio=resize_ratio,
+                                                          final_size=final_size,
+                                                          stride_ratio=stride_ratio)
+    assert list(reshaped_X.shape) == [X_data.shape[0] * 4] + list(X_data.shape[1:])
+    assert list(reshaped_y.shape) == [y_data.shape[0] * 4] + list(y_data.shape[1:])
 
 
 def test_pad_image_stack():
@@ -70,56 +165,59 @@ def test_pad_image_stack():
 
 def test_combine_npz_files():
     # NPZ files are appropriate size and resolution
-    npz_list = _make_npzs((256, 256), 2)
-    resize_ratios = [1] * 2
+    num_images = [2, 2]
+    sizes = [(256, 256), (256, 256)]
+    npz_list = _make_npzs(sizes=sizes, num_images=num_images)
+    resize_ratios = [[1], [1]]
     final_size = (256, 256)
 
-    combined_npz = build.combine_npz_files(npz_list=npz_list, resize_ratios=resize_ratios,
-                                           final_size=final_size)
-
-    combined_x, combined_y = combined_npz
+    combined_x, combined_y = build.combine_npz_files(npz_list=npz_list,
+                                                     resize_ratios=resize_ratios,
+                                                     final_size=final_size)
 
     # check that correct number of NPZs present
-    assert combined_x.shape[0] == len(npz_list)
+    assert combined_x.shape[0] == np.sum(num_images)
 
     # check correct size of NPZs
     assert combined_x.shape[1:3] == final_size
 
     # NPZ files need to be cropped
-    npz_crop_list = _make_npzs((512, 512), 3)
-    resize_ratios = [1] * 3
+    num_images = [2, 2]
+    sizes = [(512, 512), (512, 512)]
+    npz_crop_list = _make_npzs(sizes=sizes, num_images=num_images)
+    resize_ratios = [[1], [1]]
     final_size = (256, 256)
 
-    combined_npz = build.combine_npz_files(npz_list=npz_crop_list, resize_ratios=resize_ratios,
-                                           final_size=final_size)
-
-    combined_x, combined_y = combined_npz
+    combined_x, combined_y = build.combine_npz_files(npz_list=npz_crop_list,
+                                                     resize_ratios=resize_ratios,
+                                                     final_size=final_size)
 
     # check that correct number of NPZs present
-    assert combined_x.shape[0] == len(npz_crop_list) * 4
+    assert combined_x.shape[0] == np.sum(num_images) * 4
 
     # check correct size of NPZs
     assert combined_x.shape[1:3] == final_size
 
     # NPZ files need to be resized
-    npz_resize_list = _make_npzs((256, 256), 5)
-    resize_ratios = [3] * 5
+    num_images = [2, 2]
+    sizes = [(128, 128), (128, 128)]
+    npz_resize_list = _make_npzs(sizes=sizes, num_images=num_images)
+    resize_ratios = [[2], [2]]
     final_size = (256, 256)
 
-    combined_npz = build.combine_npz_files(npz_list=npz_resize_list, resize_ratios=resize_ratios,
-                                           final_size=final_size)
-
-    combined_x, combined_y = combined_npz
+    combined_x, combined_y = build.combine_npz_files(npz_list=npz_resize_list,
+                                                     resize_ratios=resize_ratios,
+                                                     final_size=final_size)
 
     # check that correct number of NPZs present
-    assert combined_x.shape[0] == len(npz_resize_list) * (resize_ratios[0] ** 2)
+    assert combined_x.shape[0] == np.sum(num_images)
 
     # check correct size of NPZs
     assert combined_x.shape[1:3] == final_size
 
     # some need to be cropped, some need to be resized
     npz_list = npz_crop_list + npz_resize_list
-    resize_ratios = [1] * 3 + [3] * 5
+    resize_ratios = [[1], [1], [2], [2]]
     final_size = (256, 256)
 
     combined_npz = build.combine_npz_files(npz_list=npz_list, resize_ratios=resize_ratios,
@@ -128,8 +226,24 @@ def test_combine_npz_files():
     combined_x, combined_y = combined_npz
 
     # check that correct number of NPZs present
-    assert combined_x.shape[0] == (len(npz_crop_list) * 4 +
-                                   len(npz_resize_list) * (resize_ratios[4] ** 2))
+    assert combined_x.shape[0] == (np.sum(num_images) + np.sum(num_images) * 4)
+
+    # check correct size of NPZs
+    assert combined_x.shape[1:3] == final_size
+
+    # different resizing for each image in the NPZ
+    num_images = [2, 2]
+    sizes = [(256, 256), (256, 256)]
+    npz_resize_list = _make_npzs(sizes=sizes, num_images=num_images)
+    resize_ratios = [[1], [1, 2]]
+    final_size = (256, 256)
+
+    combined_x, combined_y = build.combine_npz_files(npz_list=npz_resize_list,
+                                                     resize_ratios=resize_ratios,
+                                                     final_size=final_size)
+
+    # check that correct number of NPZs present
+    assert combined_x.shape[0] == np.sum(2 + 1 + 4)
 
     # check correct size of NPZs
     assert combined_x.shape[1:3] == final_size


### PR DESCRIPTION
The current version of build.py accepts a single resize parameter for an entire NPZ of images. However, if the image data within an NPZ is heterogenous, there may be different resize values that are appropriate for each image within that NPZ file. 

- This PR adds the option to specify a separate resize value for each image in an NPZ in the combine_npz_files function.

- It pulls out the core resizing and cropping functionality from combine_npz_files into a new helper function

- It adds a compute_cell_size function which calculates the mean cell size within an image, which can be used to generate those resize values. 

